### PR TITLE
fix: stopped countdown from accelerating when recording button pressed multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The project was initially developed by [Sagnik Sahoo](https://twitter.com/heysag
 
 ## Demo
 
-<a href="https://screen-rec.vercel.app/" target="_blank"><img src="https://img.shields.io/badge/Try%20ScreenREC-Live%20Demo-5F27CD?style=for-the-badge&logo=vercel&logoColor=white" alt="Live Demo" /></a>
+<a href="https://screen-rec-web.vercel.app/" target="_blank"><img src="https://img.shields.io/badge/Try%20ScreenREC-Live%20Demo-5F27CD?style=for-the-badge&logo=vercel&logoColor=white" alt="Live Demo" /></a>
 
 ## Tech Stack
 

--- a/apps/web/src/app/record/page.tsx
+++ b/apps/web/src/app/record/page.tsx
@@ -228,6 +228,10 @@ export default function RecordPage() {
 
   const startCountdown = useCallback(() => {
     setCountdown(3);
+    
+    if (countdownIntervalRef.current) {
+      clearInterval(countdownIntervalRef.current);
+    }
 
     countdownIntervalRef.current = setInterval(() => {
       setCountdown((prev) => {


### PR DESCRIPTION
- when recording button was pressed multiple times before countdown finished then the countdown would accelerate due to multiple setIntervals being created. Small check added to stop this
- Demo website in README updated