### PR TITLE
docs: fix Product Hunt badge copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A modern, privacy-first web screen recorder. No ads, no time limits, no data collection.
 
-<a href="https://www.producthunt.com/posts/screenrec-2?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-screenrec" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1049697&theme=dark" alt="ScreenREC - A really simple ad-free minimial web screen recorder | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+<a href="https://www.producthunt.com/posts/screenrec-2?utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-screenrec" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1049697&theme=dark" alt="ScreenREC - A really simple ad-free minimal web screen recorder | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
 ## About
 


### PR DESCRIPTION
## Summary
- Fix the Product Hunt badge alt text typo
- Replace the misspelled UTM parameter with a campaign parameter

## Testing
- git diff --check

No app build was run because this is a README-only change.